### PR TITLE
Fixed error and changed echo to PHP warning

### DIFF
--- a/SMDecoder/SMDecoder.php
+++ b/SMDecoder/SMDecoder.php
@@ -56,9 +56,7 @@
 	define("TAG_INT",			chr(253));
 	define("TAG_SHORT",			chr(254));
 	define("TAG_BYTE",			chr(255));
-
-
-
+    
 	class SMDecoder{
 		private $stream;
 		private $type;
@@ -949,7 +947,7 @@
 				break;
 
 				default:
-					echo 'Warning: Unrecognized tag type in parseTag() -> '. dechex(ord($type)). chr(13).chr(10);
+                    trigger_error( 'Unrecognized tag type in parseTag() -> '. dechex(ord($type)). chr(13).chr(10) , E_USER_WARNING );
 				break;
 			}
 
@@ -1011,7 +1009,7 @@
 				break;
 
 				default:
-					echo 'Warning: Unrecognized tag type  in parseList() -> '. dechex(ord($type)). chr(13).chr(10);
+                  trigger_error( 'Unrecognized tag type  in parseList() -> '. dechex(ord($type)). chr(13).chr(10) , E_USER_WARNING );
 					break;
 			}
 
@@ -1426,7 +1424,7 @@
 				'r' => $r,
 				'g' => $g,
 				'b' => $b,
-				'a' => $a]
+				'a' => $a,
 			);
 		}
 


### PR DESCRIPTION
There was an error in colorRGBA method there was an ] instead a comma.
Changed warning echo to trigger_error PHP function as a Warning to be able to hide them in production.
