### PR TITLE
Fixed error decoding files

### DIFF
--- a/SMDecoder/SMDecoder.php
+++ b/SMDecoder/SMDecoder.php
@@ -56,7 +56,7 @@
 	define("TAG_INT",			chr(253));
 	define("TAG_SHORT",			chr(254));
 	define("TAG_BYTE",			chr(255));
-    
+
 	class SMDecoder{
 		private $stream;
 		private $type;
@@ -185,7 +185,7 @@
 			$data['gzip'] = $this->readInt16();
 			$tag = $this->readByte();
 
-			while($tag != TAG_FINISH){
+			while( ord($tag) != TAG_FINISH){
 
 				$resp = $this->parseTag($tag);
 


### PR DESCRIPTION
Not fully tested, needs additional check to assure the data extracted is correct, but now does not fails to open planets, stations, ships, catalog and factions (not tested with asteroids and other files)
